### PR TITLE
Develop

### DIFF
--- a/R/create_app.R
+++ b/R/create_app.R
@@ -81,6 +81,9 @@ create_app <- function(app_name,
     app_repo_url = dots$app_repo_url, auth_user = dots$auth_user,
     auth_pw = dots$auth_pw, user_browser = dots$user_browser)
 
+  # Account for pandoc
+  pandoc_file_copy(app_dir)
+
   # Build the iss script
   iss <- start_iss(app_name)
 

--- a/R/install_pandoc.R
+++ b/R/install_pandoc.R
@@ -1,0 +1,53 @@
+#' @title Downloads and installs pandoc
+#' @description Downloads and installs the latest version of pandoc for Windows.
+#' @details
+#' pandoc is a free open source software for converting documents from many filetypes to many filetypes.  For details, see \url{http://johnmacfarlane.net/pandoc/}.
+#'
+#' Credit: the code in this function is based on GERGELY DAROCZIs coding in his answer on the Q&A forum StackOverflow, and also G. Grothendieck for the non-XML addition to the function.
+#' I thank them both!
+#' @return TRUE/FALSE - was the installation successful or not.
+#' @export
+#' @author GERGELY DAROCZI, G. Grothendieck, Tal Galili
+#' @param URL a link to the list of download links of pandoc
+#' @param use_regex (default TRUE) - deprecated (kept for legacy purposes).
+#' @param to_restart boolean. Should the computer be restarted
+#'  after pandoc is installed? (if missing then the user is prompted
+#' 	for a decision)
+#' @param ... extra parameters to pass to \link{install.URL}
+#' @source \url{http://stackoverflow.com/questions/15071957/is-it-possible-to-install-pandoc-on-windows-using-an-r-command}
+#' @examples
+#' \dontrun{
+#' install.pandoc()
+#' }
+
+install_pandoc <- function (URL = "https://github.com/jgm/pandoc/releases",
+          to_restart, ...)
+{
+  page_with_download_url <- URL
+
+  page <- readLines(page_with_download_url, warn = FALSE)
+  pat <- "jgm/pandoc/releases/download/[0-9.]+/pandoc-[0-9.-]+-windows\\.msi"
+  target_line <- grep(pat, page, value = TRUE)
+  m <- regexpr(pat, target_line)
+  URL <- regmatches(target_line, m)
+  URL <- head(URL, 1)
+  URL <- paste("https://github.com/", URL, sep = "")
+  installed <- install_URL(URL, ...)
+  if (!installed)
+    return(invisible(FALSE))
+  if (missing(to_restart)) {
+    if (is.windows()) {
+      you_should_restart <- "You should restart your computer\n in order for pandoc to work properly"
+      winDialog(type = "ok", message = you_should_restart)
+      choices <- c("Yes", "No")
+      question <- "Do you want to restart your computer now?"
+      the_answer <- menu(choices, graphics = "TRUE", title = question)
+      to_restart <- the_answer == 1L
+    }
+    else {
+      to_restart <- FALSE
+    }
+  }
+  if (to_restart)
+    os.restart()
+}

--- a/R/install_url.R
+++ b/R/install_url.R
@@ -1,0 +1,94 @@
+#' @title Downloads and runs a .exe installer file for some software from a URL
+#' @description Gets a character with a link to an installer file, downloads it, runs it, and then erases it.
+#' @details
+#' This function is used by many functions in the installr package.
+#' The .exe file is downloaded into a temporary directory, where it is erased after installation has started (by default - though this can be changed)
+#' @param exe_URL A character with a link to an installer file (with the .exe file extension)
+#' @param keep_install_file If TRUE - the installer file will not be erased after it is downloaded and run.
+#' @param wait should the R interpreter wait for the command to finish? The default is to NOT wait.
+#' @param download_dir A character of the directory into which to download the file. (default is \link{tempdir}())
+#' @param message boolean. Should a message on the file be printed or not (default is TRUE)
+#' @param installer_option A character of the command line arguments
+#' @param download_fun a function to use for downloading. Default is \link{download.file}. We can also use
+#' \link[curl]{curl_download} (but it doesn't give as good of an output while downloading the file).
+#' @param ... parameters passed to 'shell'
+#' @return invisible(TRUE/FALSE) - was the installation successful or not. (this is based on the output of shell of running the command being either 0 or 1/2.  0 means the file was successfully installed, while 1 or 2 means there was a failure in running the installer.)
+#' @seealso \link{shell}
+#' @export
+#' @author GERGELY DAROCZI, Tal Galili
+#' @examples
+#' \dontrun{
+#' install.URL("adfadf") # shows the error produced when the URL is not valid.
+#' }
+
+install_URL <- function(exe_URL, keep_install_file = FALSE, wait = TRUE, download_dir = tempdir(), message = TRUE, installer_option = NULL, download_fun = download.file, ...) {
+  # source: http://stackoverflow.com/questions/15071957/is-it-possible-to-install-pandoc-on-windows-using-an-r-command
+  # input: a url of an .exe file to install
+  # output: it runs the .exe file (for installing something)
+
+  havingIP <- function() {
+    if (.Platform$OS.type == "windows") {
+      ipmessage <- system("ipconfig", intern = TRUE)
+    } else {
+      ipmessage <- system("ifconfig", intern = TRUE)
+    }
+    validIP <- "((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.]){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+    any(grep(validIP, ipmessage))
+  }
+
+
+  if(!havingIP()) warning("You do not seem to be connected to the internet. Hence - you will likely not be able to download software.")
+
+
+  exe_filename <- file.path(download_dir, basename(exe_URL))   # the name of the zip file MUST be as it was downloaded...
+  # tryCatch(curl::curl_download(exe_URL, destfile=exe_filename, quiet = FALSE, mode = 'wb'),
+  tryCatch(download_fun(exe_URL, destfile=exe_filename, quiet = FALSE, mode = 'wb'),
+           error = function(e) {
+             cat("\nExplanation of the error: You didn't enter a valid .EXE URL. \nThis is likely to have happened because there was a change in the URL of the installer file in the download page of the software (making our function unable to know what to download). If you think this is the problem, please mail the author jon.mark.hill@gmail.com\n")
+             return(invisible(FALSE))
+           })
+
+  # check if we downloaded the file.
+  if(file.exists(exe_filename)) {
+    if(message) cat("\nThe file was downloaded successfully into:\n", exe_filename, "\n")
+  } else {
+    if(message) cat("\nWe failed to download the file into:\n", exe_filename, "\n(i.e.: the installation failed)\n")
+    return(invisible(FALSE))
+  }
+
+  if(!keep_install_file & !wait) {
+    wait <- TRUE
+    if(message) cat("wait was set to TRUE since you wanted to installation file removed. In order to be able to run the installer AND remove the file - we must first wait for the installer to finish running before removing the file.")
+  }
+
+  if(message) cat("\nRunning the installer now...\n")
+
+
+  if(!is.null(installer_option)){
+    install_cmd <- paste(exe_filename, installer_option)
+  } else{
+    install_cmd <- exe_filename
+  }
+
+  is.windows <- function(...) unname(Sys.info()["sysname"] == "Windows")
+
+  if(is.windows()) {
+    shell_output <- shell(install_cmd, wait = wait,...) # system(exe_filename) # I suspect shell works better than system
+  } else {
+    shell_output <- system(install_cmd, wait = wait,...) # system(exe_filename) # I suspect shell works better than system
+  }
+  if(!keep_install_file) {
+    if(message) cat("\nInstallation status: ", shell_output == 0 ,". Removing the file:\n", exe_filename, "\n (In the future, you may keep the file by setting keep_install_file=TRUE) \n")
+    unlink(exe_filename, force = TRUE) # on.exit(unlink(exe_filename)) # on.exit doesn't work in case of problems in the running of the file
+  }
+  # unlink can take some time until done, for some reason.
+  #    file.remove(exe_filename)
+  #    file.info(exe_filename)
+  #    file.access(exe_filename, mode = 0)
+  #    file.access(exe_filename, mode = 1)
+  #    file.access(exe_filename, mode = 2)
+  #    file.access(exe_filename, mode = 3)
+  return(invisible(shell_output == 0))
+  # error code 1/2 means that we couldn't finish running the file
+  # # 0 means - the file was successfully installed.
+}

--- a/R/pandoc_file_copy.R
+++ b/R/pandoc_file_copy.R
@@ -1,0 +1,20 @@
+# Copy pandoc files to app directory
+pandoc_file_copy <- function(app_dir){
+  config <- jsonlite::fromJSON(file.path(app_dir, "utils/config.cfg"))
+  if(config$flex_file != "none"){
+
+    pandoc_path <- ifelse(Sys.getenv("RSTUDIO_PANDOC") == "", "none", Sys.getenv("RSTUDIO_PANDOC"))
+
+    if(pandoc_path != "none"){
+      copy_status <- file.copy(pandoc_path, paste0(app_dir,"/utils/"), recursive = T)
+      if(copy_status == T)
+      {
+        message("Pandoc included into utils for Flexdashboard\n")
+      } else {
+        stop("The necessary Pandoc files, which is a dependency of Flexdashboards could not be copied into the designated app library folder\n")
+      }
+    } else(
+      stop("The necessary Pandoc files, which is a dependency of Flexdashboards could not found. Please run the `install_pandoc()` function before trying to compile to install the necessary files that are required to run a Flexdashboard shiny app\n")
+    )
+  }
+}

--- a/inst/installation/app.R
+++ b/inst/installation/app.R
@@ -41,7 +41,7 @@ if (config$app_repo[[1]] != "none") {
   # flexdashboard
   if (config$flex_file != "none") {
 
-    Sys.setenv(RSTUDIO_PANDOC = paste0(getwd(),"/library/pandoc/"))
+    Sys.setenv(RSTUDIO_PANDOC = paste0(getwd(),.libPaths(),"/pandoc/"))
     rmarkdown::run(file.path(app_path, config$flex_file),
                    shiny_args = list(host = '0.0.0.0', launch.browser = T))
   # Shiny
@@ -52,7 +52,7 @@ if (config$app_repo[[1]] != "none") {
 } else {
   # flexdashboard
   if (config$flex_file != "none") {
-    Sys.setenv(RSTUDIO_PANDOC = paste0(getwd(),"/library/pandoc/"))
+    Sys.setenv(RSTUDIO_PANDOC = paste0(getwd(),.libPaths(),"/pandoc/"))
     rmarkdown::run(paste0("./", config$flex_file),
                    shiny_args = list(host = '0.0.0.0', launch.browser = T))
   # Shiny

--- a/inst/installation/app.R
+++ b/inst/installation/app.R
@@ -41,7 +41,7 @@ if (config$app_repo[[1]] != "none") {
   # flexdashboard
   if (config$flex_file != "none") {
 
-    Sys.setenv(RSTUDIO_PANDOC = paste0(app_path,"/utils/pandoc/"))
+    Sys.setenv(RSTUDIO_PANDOC = file.path(app_path,"/utils/pandoc/"))
     rmarkdown::run(file.path(app_path, config$flex_file),
                    shiny_args = list(host = '0.0.0.0', launch.browser = T))
   # Shiny
@@ -52,7 +52,7 @@ if (config$app_repo[[1]] != "none") {
 } else {
   # flexdashboard
   if (config$flex_file != "none") {
-    Sys.setenv(RSTUDIO_PANDOC = paste0(app_path,"/utils/pandoc/"))
+    Sys.setenv(RSTUDIO_PANDOC = file.path(app_path,"/utils/pandoc/"))
     rmarkdown::run(paste0("./", config$flex_file),
                    shiny_args = list(host = '0.0.0.0', launch.browser = T))
   # Shiny

--- a/inst/installation/app.R
+++ b/inst/installation/app.R
@@ -41,7 +41,7 @@ if (config$app_repo[[1]] != "none") {
   # flexdashboard
   if (config$flex_file != "none") {
 
-    Sys.setenv(RSTUDIO_PANDOC = paste0(getwd(),.libPaths(),"/pandoc/"))
+    Sys.setenv(RSTUDIO_PANDOC = paste0(app_path,"/utils/pandoc/"))
     rmarkdown::run(file.path(app_path, config$flex_file),
                    shiny_args = list(host = '0.0.0.0', launch.browser = T))
   # Shiny
@@ -52,7 +52,7 @@ if (config$app_repo[[1]] != "none") {
 } else {
   # flexdashboard
   if (config$flex_file != "none") {
-    Sys.setenv(RSTUDIO_PANDOC = paste0(getwd(),.libPaths(),"/pandoc/"))
+    Sys.setenv(RSTUDIO_PANDOC = paste0(app_path,"/utils/pandoc/"))
     rmarkdown::run(paste0("./", config$flex_file),
                    shiny_args = list(host = '0.0.0.0', launch.browser = T))
   # Shiny

--- a/inst/installation/app.R
+++ b/inst/installation/app.R
@@ -40,6 +40,8 @@ if (config$app_repo[[1]] != "none") {
 
   # flexdashboard
   if (config$flex_file != "none") {
+
+    Sys.setenv(RSTUDIO_PANDOC = paste0(getwd(),"/library/pandoc/"))
     rmarkdown::run(file.path(app_path, config$flex_file),
                    shiny_args = list(host = '0.0.0.0', launch.browser = T))
   # Shiny
@@ -50,6 +52,7 @@ if (config$app_repo[[1]] != "none") {
 } else {
   # flexdashboard
   if (config$flex_file != "none") {
+    Sys.setenv(RSTUDIO_PANDOC = paste0(getwd(),"/library/pandoc/"))
     rmarkdown::run(paste0("./", config$flex_file),
                    shiny_args = list(host = '0.0.0.0', launch.browser = T))
   # Shiny

--- a/inst/installation/package_manager.R
+++ b/inst/installation/package_manager.R
@@ -32,7 +32,33 @@ message("working path:\n", paste("...", appwd))
 library("jsonlite", character.only = TRUE)
 library("devtools", character.only = TRUE)
 library("httr", character.only = TRUE)
+
 config <- jsonlite::fromJSON(file.path(appwd, "utils/config.cfg"))
+reg_paths <- jsonlite::fromJSON("utils/regpaths.json")
+
+# Copy pandoc files to app directory
+
+if(config$flex_file != "none"){
+
+  if(reg_paths$pandoc == "none"){
+    pandoc_path <- ifelse(Sys.getenv("RSTUDIO_PANDOC") == "", "none", Sys.getenv("RSTUDIO_PANDOC"))
+  } else {
+    pandoc_path <- reg_paths$pandoc
+  }
+
+  if(pandoc_path != "none"){
+    copy_status <- file.copy(reg_paths$pandoc, .libPaths(), recursive = T)
+    if(copy_status == T)
+    {
+      message("Pandoc paths:\n", paste0("... ", .libPaths(), collapse = "\n"))
+    } else {
+      stop("The necessary Pandoc files, which is a dependency of Flexdashboards could not be copied into the designated app library folder\n")
+    }
+  } else(
+    stop("The necessary Pandoc files, which is a dependency of Flexdashboards could not found. Please run the `install_pandoc()` function before trying to compile to install the necessary files that are required to run a Flexdashboard shiny app\n")
+  )
+}
+
 
 # Package dependency list
 pkgs <- config$pkgs$pkgs; remotes <- config$remotes

--- a/inst/installation/package_manager.R
+++ b/inst/installation/package_manager.R
@@ -3,6 +3,9 @@
 appwd <- getwd()
 applibpath <- file.path(appwd, "library")
 
+config <- jsonlite::fromJSON(file.path(appwd, "utils/config.cfg"))
+reg_paths <- jsonlite::fromJSON("utils/regpaths.json")
+
 # Create app/library if it doesn't exist (e.g. first run)
 # Initialize RInno
 if (!dir.exists(applibpath)) {
@@ -32,27 +35,6 @@ message("working path:\n", paste("...", appwd))
 library("jsonlite", character.only = TRUE)
 library("devtools", character.only = TRUE)
 library("httr", character.only = TRUE)
-
-config <- jsonlite::fromJSON(file.path(appwd, "utils/config.cfg"))
-reg_paths <- jsonlite::fromJSON("utils/regpaths.json")
-
-# Copy pandoc files to app directory
-
-if(config$flex_file != "none"){
-
-  if(pandoc_path != "none"){
-    copy_status <- file.copy(reg_paths$pandoc, .libPaths(), recursive = T)
-    if(copy_status == T)
-    {
-      message("Pandoc paths:\n", paste0("... ", .libPaths(), collapse = "\n"))
-    } else {
-      stop("The necessary Pandoc files, which is a dependency of Flexdashboards could not be copied into the designated app library folder\n")
-    }
-  } else(
-    stop("The necessary Pandoc files, which is a dependency of Flexdashboards could not found. Please run the `install_pandoc()` function before trying to compile to install the necessary files that are required to run a Flexdashboard shiny app\n")
-  )
-}
-
 
 # Package dependency list
 pkgs <- config$pkgs$pkgs; remotes <- config$remotes

--- a/inst/installation/package_manager.R
+++ b/inst/installation/package_manager.R
@@ -40,12 +40,6 @@ reg_paths <- jsonlite::fromJSON("utils/regpaths.json")
 
 if(config$flex_file != "none"){
 
-  if(reg_paths$pandoc == "none"){
-    pandoc_path <- ifelse(Sys.getenv("RSTUDIO_PANDOC") == "", "none", Sys.getenv("RSTUDIO_PANDOC"))
-  } else {
-    pandoc_path <- reg_paths$pandoc
-  }
-
   if(pandoc_path != "none"){
     copy_status <- file.copy(reg_paths$pandoc, .libPaths(), recursive = T)
     if(copy_status == T)


### PR DESCRIPTION
Integration and shipping of pandoc when using flex framework.

* The reg_paths option only works if you "installed" pandoc from an installer. If you are like me, I am using the pandoc that is shipped with RStudio, then it is not registered in the registry. But when i run `Sys.getenv()` I do get the path to my pandoc binaries, so I think you should perhaps build in both to write to the 'reg_paths' file for us perhaps...

* When your run `RInno_installer.exe`, we should treat that environment separate from the developers. Thus, if we are creating a flexdashboard app, we always ship `pandoc` along - irrespective of what the developers environment looks like. Thus the app is a self-contained unit and makes install, shipping and uninstall easier. So even if the 'user` of the app has pandoc installed on his/her computer it doesnt matter, the app will use the one that shipped with the app that we know works.(see attached file, [RInno.zip](https://github.com/ficonsulting/RInno/files/1117815/RInno.zip), for my conceptual idea. This file can be loaded at https://www.draw.io/)

* I copy the pandoc files over in the `create_app.R` file and set the Env variables in App.R
Currently I just copy the pandoc that RSTUDIO uses, purely out of the assumption that whoever designed the app, will also package and ship it... not the best assumption. But hopefully for now, a working one