### PR TITLE
Invalid example (missing semicolon)

### DIFF
--- a/inst/installation/code.iss
+++ b/inst/installation/code.iss
@@ -25,7 +25,7 @@ begin
     for v := 0 to (RVersions.Count - 1) do
       begin
         if RegKeyExists(HKLM, 'Software\R-Core\R\' + RVersions[v]) or RegKeyExists(HKCU, 'Software\R-Core\R\' + RVersions[v]) then
-          success := true
+          success := true;
         if success then
           begin
             RRegKey := 'Software\R-Core\R\' + RVersions[v];


### PR DESCRIPTION
This PR will fix the toy example (missing semicolon error, line 123) given in the README.md:

```r
# devtools::install_github("Laurae2/RInno@patch-1")
library(RInno)

# Example app included with RInno package
example_app(wd = getwd())

# Build an installer
create_app(app_name = "Your appname", app_dir = "app")
compile_iss() # it causes compilation error without adding the semicolon in line 123
```

Setup tested:

* Official R 3.4.4
* Inno Setup 5.5.9 installed by myself