### PR TITLE
143 Added path to find Inno installed by a non admin user

### DIFF
--- a/R/compile_iss.R
+++ b/R/compile_iss.R
@@ -37,7 +37,8 @@ compile_iss <- function() {
 
 find_inno <- function(){
   progs <- c(list.dirs("C:/Program Files", TRUE, FALSE),
-             list.dirs("C:/Program Files (x86)", TRUE, FALSE))
+             list.dirs("C:/Program Files (x86)", TRUE, FALSE),
+             list.dirs(paste(Sys.getenv("LOCALAPPDATA"), "Programs", sep="/"), TRUE, FALSE))
 
   inno <- progs[grep("Inno Setup", progs)]
 


### PR DESCRIPTION
Updated search path to enable `compile_iss()` to find Inno installed by a non admin user.

https://github.com/ficonsulting/RInno/issues/143