### PR TITLE
Added path to find Inno installed by a non admin user (setup_section.R)

### DIFF
--- a/R/setup_section.R
+++ b/R/setup_section.R
@@ -112,7 +112,8 @@ setup_section <- function(iss, app_dir, dir_out,
 
     # Find the Inno Setup folder
     progs <- c(list.dirs("C:/Program Files", T, F),
-               list.dirs("C:/Program Files (x86)", T, F))
+               list.dirs("C:/Program Files (x86)", T, F),
+               list.dirs(paste(Sys.getenv("LOCALAPPDATA"), "Programs", sep="/"), T, F))
     inno <- progs[grep("Inno Setup", progs)]
 
     # Check for the encryption Module


### PR DESCRIPTION
This implements the suggestion in https://github.com/ficonsulting/RInno/pull/144#issuecomment-613414727 and would fix issue https://github.com/ficonsulting/RInno/issues/143 together with pr https://github.com/ficonsulting/RInno/pull/144.